### PR TITLE
Upgrade "definitions" to "$defs" in "$ref" JSON Pointers

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -18,6 +18,9 @@ async function transformer (root, path, ruleset) {
         // TODO: Use standard JSON-e operators instead
         omit: (object, keys) => {
           return _.omit(object, _.castArray(keys))
+        },
+        replace: (value, string, replacement) => {
+          return value.replaceAll(string, replacement)
         }
       })
 

--- a/rules/jsonschema-draft7-to-2019-09.json
+++ b/rules/jsonschema-draft7-to-2019-09.json
@@ -74,6 +74,31 @@
       "vocabulary": "core",
       "condition": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/sourcemeta/alterschema/rules/jsonschema-draft7-to-2019-09/definitions-in-ref",
+        "type": "object",
+        "required": [ "$ref" ],
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "/definitions/"
+          }
+        }
+      },
+      "transform": {
+        "$merge": [
+          { "$eval": "omit(schema, '$ref')" },
+          {
+            "$$ref": {
+              "$eval": "replace(schema['$ref'], 'definitions', '$defs')"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "vocabulary": "core",
+      "condition": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": "https://github.com/sourcemeta/alterschema/rules/jsonschema-draft7-to-2019-09/empty-object",
         "const": {}
       },

--- a/test/rules/jsonschema-draft4-to-2019-09.json
+++ b/test/rules/jsonschema-draft4-to-2019-09.json
@@ -82,12 +82,22 @@
     "name": "draft4 definitions",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
       "definitions": {
         "foo": { "type": "string" }
       }
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
       "$defs": {
         "foo": { "type": "string" }
       }

--- a/test/rules/jsonschema-draft4-to-2020-12.json
+++ b/test/rules/jsonschema-draft4-to-2020-12.json
@@ -82,12 +82,22 @@
     "name": "draft4 definitions",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
       "definitions": {
         "foo": { "type": "string" }
       }
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
       "$defs": {
         "foo": { "type": "string" }
       }

--- a/test/rules/jsonschema-draft6-to-2019-09.json
+++ b/test/rules/jsonschema-draft6-to-2019-09.json
@@ -23,12 +23,22 @@
     "name": "draft6 definitions",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
       "definitions": {
         "foo": { "type": "string" }
       }
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
       "$defs": {
         "foo": { "type": "string" }
       }

--- a/test/rules/jsonschema-draft6-to-2020-12.json
+++ b/test/rules/jsonschema-draft6-to-2020-12.json
@@ -23,12 +23,22 @@
     "name": "draft6 definitions",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
       "definitions": {
         "foo": { "type": "string" }
       }
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
       "$defs": {
         "foo": { "type": "string" }
       }

--- a/test/rules/jsonschema-draft7-to-2019-09.json
+++ b/test/rules/jsonschema-draft7-to-2019-09.json
@@ -23,12 +23,22 @@
     "name": "draft7 definitions",
     "schema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
       "definitions": {
         "foo": { "type": "string" }
       }
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
       "$defs": {
         "foo": { "type": "string" }
       }

--- a/test/rules/jsonschema-draft7-to-2020-12.json
+++ b/test/rules/jsonschema-draft7-to-2020-12.json
@@ -35,6 +35,31 @@
     }
   },
   {
+    "name": "draft7 definitions",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      },
+      "definitions": {
+        "foo": { "type": "string" }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": {
+          "$ref": "#/$defs/foo"
+        }
+      },
+      "$defs": {
+        "foo": { "type": "string" }
+      }
+    }
+  },
+  {
     "name": "true no metaschema",
     "schema": {},
     "expected": true


### PR DESCRIPTION
While we currently upgrade "definitions" to "$defs" in the JSON Schema
definition, pointers going through "definitions" are currently left
intact.

See: https://github.com/sourcemeta/alterschema/issues/43
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
