### PR TITLE
Fix collapsing { "not": {} } schemas into "false"

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -51,6 +51,12 @@ module.exports = async (value, from, to) => {
     })
 
     for (const trail of trails) {
+      // The trail might not be valid anymore if there were mid-way
+      // transformation rules that changed the layout of the schema
+      if (trail.path.length > 0 && !_.has(accumulator, trail.path)) {
+        continue
+      }
+
       const transform = await transformer(accumulator, trail.path, mapper.rules)
       if (trail.path.length === 0) {
         accumulator = transform

--- a/bindings/node/test.js
+++ b/bindings/node/test.js
@@ -73,7 +73,6 @@ const BLACKLIST = [
   'items',
   'maxLength',
   'minLength',
-  'not',
   'recursiveRef',
   'ref',
   'refRemote',

--- a/test/rules/jsonschema-2019-09-to-2020-12.json
+++ b/test/rules/jsonschema-2019-09-to-2020-12.json
@@ -96,5 +96,22 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft4-to-2019-09.json
+++ b/test/rules/jsonschema-draft4-to-2019-09.json
@@ -191,5 +191,22 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft4-to-2020-12.json
+++ b/test/rules/jsonschema-draft4-to-2020-12.json
@@ -191,5 +191,22 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft4-to-draft6.json
+++ b/test/rules/jsonschema-draft4-to-draft6.json
@@ -109,5 +109,22 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "const": "single-value"
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft4-to-draft7.json
+++ b/test/rules/jsonschema-draft4-to-draft7.json
@@ -98,5 +98,22 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "const": "single-value"
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft6-to-2019-09.json
+++ b/test/rules/jsonschema-draft6-to-2019-09.json
@@ -132,5 +132,22 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft6-to-2020-12.json
+++ b/test/rules/jsonschema-draft6-to-2020-12.json
@@ -132,5 +132,22 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft6-to-draft7.json
+++ b/test/rules/jsonschema-draft6-to-draft7.json
@@ -28,5 +28,22 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "const": "single-value"
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft7-to-2019-09.json
+++ b/test/rules/jsonschema-draft7-to-2019-09.json
@@ -132,5 +132,22 @@
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]

--- a/test/rules/jsonschema-draft7-to-2020-12.json
+++ b/test/rules/jsonschema-draft7-to-2020-12.json
@@ -147,5 +147,22 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [ "foo", "bar" ]
     }
+  },
+  {
+    "name": "properties with a not: {} schema",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "foo": {
+          "not": {}
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "foo": false
+      }
+    }
   }
 ]


### PR DESCRIPTION
The main problem with this at the moment is that further rules evaluated
after the transformation will attempt to apply to non-existent
sub-schemas, resulting in pretty much undefined behavior.

See: https://github.com/sourcemeta/alterschema/issues/1
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
