### PR TITLE
Iteratively apply walker on the transformed schema

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -46,7 +46,7 @@ module.exports = async (value, from, to) => {
   }
 
   for (const mapper of builtin.jsonschema[from][to]) {
-    const trails = walker(mapper.walker, value, []).sort((a, b) => {
+    const trails = walker(mapper.walker, accumulator, []).sort((a, b) => {
       return b.path.length - a.path.length
     })
 

--- a/bindings/node/test.js
+++ b/bindings/node/test.js
@@ -76,7 +76,6 @@ const BLACKLIST = [
   'content',
   'dependencies',
   'id',
-  'items',
   'recursiveRef',
   'ref',
   'refRemote',

--- a/test/rules/jsonschema-draft7-to-2020-12.json
+++ b/test/rules/jsonschema-draft7-to-2020-12.json
@@ -164,5 +164,24 @@
         "foo": false
       }
     }
+  },
+  {
+    "name": "array items within definitions",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "item": {
+          "items": [ { "type": "string" } ]
+        }
+      }
+    },
+    "expected": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "item": {
+          "prefixItems": [ { "type": "string" } ]
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
Right now, we apply the walkers on the original schema only, which means
we do not consider sub-schemas on a location where the path changed
because of another transformation (like `definitions` to `$defs`).

This change makes the "items" suite of the JSON Schema official tests
pass now.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
