### PR TITLE
Replace incorrect dependentProperties with dependentRequired

### DIFF
--- a/bindings/node/test.js
+++ b/bindings/node/test.js
@@ -68,7 +68,6 @@ for (const name of fs.readdirSync(path.resolve(__dirname, '..', '..', 'test', 'r
 const BLACKLIST = [
   'anchor',
   'content',
-  'dependencies',
   'id',
   'recursiveRef',
   'ref',
@@ -183,7 +182,7 @@ tap.test('(CLI) draft4 => 2020-12', (test) => {
   test.strictSame(JSON.parse(result.stdout.toString()), {
     $id: 'http://example.com/schema',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
-    dependentProperties: {
+    dependentRequired: {
       foo: ['bar']
     },
     properties: {

--- a/rules/jsonschema-2019-09-to-2019-09.json
+++ b/rules/jsonschema-2019-09-to-2019-09.json
@@ -22,17 +22,17 @@
       "vocabulary": "https://json-schema.org/draft/2019-09/vocab/applicator",
       "condition": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://github.com/sourcemeta/alterschema/rules/jsonschema-2019-09-to-2019-09/empty-dependent-properties",
+        "$id": "https://github.com/sourcemeta/alterschema/rules/jsonschema-2019-09-to-2019-09/empty-dependent-required",
         "type": "object",
-        "required": [ "dependentProperties" ],
+        "required": [ "dependentRequired" ],
         "properties": {
-          "dependentProperties": {
+          "dependentRequired": {
             "const": {}
           }
         }
       },
       "transform": {
-        "$eval": "omit(schema, 'dependentProperties')"
+        "$eval": "omit(schema, 'dependentRequired')"
       }
     }
   ]

--- a/rules/jsonschema-draft7-to-2019-09.json
+++ b/rules/jsonschema-draft7-to-2019-09.json
@@ -160,7 +160,7 @@
         "$merge": [
           { "$eval": "omit(schema, 'dependencies')" },
           {
-            "dependentProperties": {
+            "dependentRequired": {
               "$map": {
                 "$eval": "schema.dependencies"
               },

--- a/test/rules/jsonschema-draft4-to-2019-09.json
+++ b/test/rules/jsonschema-draft4-to-2019-09.json
@@ -125,7 +125,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "dependencies": {
@@ -142,7 +142,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -167,7 +167,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "dependencies": {
@@ -176,7 +176,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }

--- a/test/rules/jsonschema-draft4-to-2020-12.json
+++ b/test/rules/jsonschema-draft4-to-2020-12.json
@@ -125,7 +125,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "dependencies": {
@@ -142,7 +142,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -167,7 +167,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "dependencies": {
@@ -176,7 +176,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }

--- a/test/rules/jsonschema-draft6-to-2019-09.json
+++ b/test/rules/jsonschema-draft6-to-2019-09.json
@@ -66,7 +66,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "dependencies": {
@@ -83,7 +83,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -108,7 +108,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "dependencies": {
@@ -117,7 +117,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }

--- a/test/rules/jsonschema-draft6-to-2020-12.json
+++ b/test/rules/jsonschema-draft6-to-2020-12.json
@@ -66,7 +66,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "dependencies": {
@@ -83,7 +83,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -108,7 +108,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "dependencies": {
@@ -117,7 +117,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }

--- a/test/rules/jsonschema-draft7-to-2019-09.json
+++ b/test/rules/jsonschema-draft7-to-2019-09.json
@@ -66,7 +66,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "dependencies": {
@@ -83,7 +83,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -108,7 +108,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "dependencies": {
@@ -117,7 +117,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }

--- a/test/rules/jsonschema-draft7-to-2020-12.json
+++ b/test/rules/jsonschema-draft7-to-2020-12.json
@@ -81,7 +81,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties and dependentSchemas",
+    "name": "dependencies to dependentRequired and dependentSchemas",
     "schema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "dependencies": {
@@ -98,7 +98,7 @@
         "bar": false,
         "baz": true
       },
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }
@@ -123,7 +123,7 @@
     }
   },
   {
-    "name": "dependencies to dependentProperties only",
+    "name": "dependencies to dependentRequired only",
     "schema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "dependencies": {
@@ -132,7 +132,7 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "dependentProperties": {
+      "dependentRequired": {
         "qux": [ "foo" ]
       }
     }


### PR DESCRIPTION
This one seems to be a mistake from
https://github.com/sourcemeta/alterschema/issues/11. There is no keyword
called `dependentProperties`. It is `dependentRequired`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
