### PR TITLE
Set remotes from the JSON Schema test suite on the tests

### DIFF
--- a/bindings/node/jsonschema.js
+++ b/bindings/node/jsonschema.js
@@ -2,6 +2,8 @@ const jsonschema = require('@hyperjump/json-schema')
 const METASCHEMAS = require('../../metaschemas.json')
 jsonschema.setMetaOutputFormat(jsonschema.FLAG)
 
+exports.implementation = jsonschema
+
 // TODO: This is a mock implementation. Ideally, we look at the metaschema
 exports.usesVocabulary = (_root, value, _vocabulary) => {
   if (typeof value === 'object' && !Array.isArray(value) && value !== null) {


### PR DESCRIPTION
This is a pre-requisite for enabling the remaining suites.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
