### PR TITLE
Add an alphabetic prefix to anchors

### DIFF
--- a/bindings/node/test.js
+++ b/bindings/node/test.js
@@ -97,21 +97,9 @@ const BLACKLIST = [
   '2019-09|anchor|$anchor inside an enum is not a real identifier|match $ref to $anchor',
 
   // TODO: Make these pass
-  '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the outer schema resource|leaf node does not match; no recursion',
-  '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the outer schema resource|leaf node matches: recursion only uses inner schema',
-  '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the outer schema resource|leaf node does not match: recursion only uses inner schema',
-  '2019-09|recursiveRef|multiple dynamic paths to the $recursiveRef keyword|recurse to anyLeafNode - floats are allowed',
-  '2019-09|recursiveRef|multiple dynamic paths to the $recursiveRef keyword|recurse to integerNode - floats are not allowed',
-  '2019-09|recursiveRef|dynamic $recursiveRef destination (not predictable at schema compile time)|numeric node',
-  '2019-09|recursiveRef|dynamic $recursiveRef destination (not predictable at schema compile time)|integer node',
   '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the initial target schema resource|leaf node does not match; no recursion',
   '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the initial target schema resource|leaf node matches: recursion uses the inner schema',
   '2019-09|recursiveRef|$recursiveRef with no $recursiveAnchor in the initial target schema resource|leaf node does not match: recursion uses the inner schema',
-  '2019-09|recursiveRef|$recursiveRef without using nesting|integer matches at the outer level',
-  '2019-09|recursiveRef|$recursiveRef without using nesting|single level match',
-  '2019-09|recursiveRef|$recursiveRef without using nesting|integer does not match as a property value',
-  '2019-09|recursiveRef|$recursiveRef without using nesting|two levels, properties match with inner definition',
-  '2019-09|recursiveRef|$recursiveRef without using nesting|two levels, no match',
 
   'ref',
   'refRemote'

--- a/rules/jsonschema-2019-09-to-2020-12.json
+++ b/rules/jsonschema-2019-09-to-2020-12.json
@@ -159,7 +159,7 @@
           { "$eval": "omit(schema, '$recursiveAnchor')" },
           {
             "$$dynamicAnchor": {
-              "$eval": "jsonHash(original)"
+              "$eval": "'anchor-' + jsonHash(original)"
             }
           }
         ]
@@ -185,7 +185,7 @@
             "$$dynamicRef": {
               "$if": "hasContext('$recursiveAnchor', true)",
               "then": {
-                "$eval": "'#' + jsonHash(original)"
+                "$eval": "'#anchor-' + jsonHash(original)"
               },
               "else": {
                 "$eval": "schema['$recursiveRef']"

--- a/test/rules/jsonschema-2019-09-to-2020-12.json
+++ b/test/rules/jsonschema-2019-09-to-2020-12.json
@@ -126,10 +126,10 @@
     },
     "expected": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$dynamicAnchor": "452249d4fa018cdc5ec4b60924df6d0177fb65b9",
+      "$dynamicAnchor": "anchor-452249d4fa018cdc5ec4b60924df6d0177fb65b9",
       "additionalProperties": false,
       "properties": {
-        "foo": { "$dynamicRef": "#452249d4fa018cdc5ec4b60924df6d0177fb65b9" }
+        "foo": { "$dynamicRef": "#anchor-452249d4fa018cdc5ec4b60924df6d0177fb65b9" }
       }
     }
   },


### PR DESCRIPTION
The official metaschemas prohibit anchors that start with a number,
which is often the case with the SHA-1 checksums we are generating.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
