### PR TITLE
Remove downgrading "TODO" docs in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,23 +14,12 @@ versions of the specification.
 Coverage
 --------
 
-### Upgrade
-
 | From    | To      | Type     | Status | Description                                                      |
 |---------|---------|----------|--------|------------------------------------------------------------------|
 | 2019-09 | 2020-12 | Lossless | Full   | JSON Schema [2019-09][2019-09] to JSON Schema [2020-12][2020-12] |
 | draft7  | 2019-09 | Lossless | Full   | JSON Schema [Draft 7][draft7] to JSON Schema [2019-09][2019-09]  |
 | draft6  | draft7  | Lossless | Full   | JSON Schema [Draft 6][draft6] to JSON Schema [Draft 7][draft7]   |
 | draft4  | draft6  | Lossless | Full   | JSON Schema [Draft 4][draft4] to JSON Schema [Draft 6][draft6]   |
-
-### Downgrade
-
-| From    | To      | Type     | Status     | Description                                                      |
-|---------|---------|----------|------------|------------------------------------------------------------------|
-| 2020-12 | 2019-09 | Lossy    | TODO       | JSON Schema [2020-12][2020-12] to JSON Schema [2019-09][2019-09] |
-| 2019-09 | draft7  | Lossy    | TODO       | JSON Schema [2019-09][2019-09] to JSON Schema [Draft 7][draft7]  |
-| draft7  | draft6  | Lossy    | TODO       | JSON Schema [Draft 7][draft7] to JSON Schema [Draft 6][draft6]   |
-| draft6  | draft4  | Lossy    | TODO       | JSON Schema [Draft 6][draft6] to JSON Schema [Draft 4][draft4]   |
 
 Transformations are transitively applied. For example, transforming from
 `draft6` to `2019-09` implies transforming `draft6` to `draft7` and `draft7` to


### PR DESCRIPTION
I briefly experimented with downgrading, but the transformations are so
lossy in various cases that I doubt this will be actually useful to
anybody (certainly doesn't seem useful for my use cases).

I'll remove the TODO mentions on this, and we can revisit later if
somebody really has a use case where such lossy transformations are OK.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
