### PR TITLE
fix: freeze @hyperjump/json-schema dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hyperjump/json-schema": "^0.23.2",
+        "@hyperjump/json-schema": "0.23.2",
         "json-e": "^4.4.3",
         "lodash": "^4.17.21",
         "object-hash": "^3.0.0"
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@hyperjump/json-schema": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.4.tgz",
-      "integrity": "sha512-4j3QDrLGTuaNYorXl2rXqdgQbjBbjDjlDHkQjONiZfMADkUU+Z2v8j5Mx1yIt/FZKL/8xnm/CG3D/Uz1L1+g8Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.2.tgz",
+      "integrity": "sha512-/m5emi8ruTGXxrsy6Pik4ipsjdUZVGePzqwm36oWtEB1DcExHnGheW/BDDBGrGZHdIqFV2PMTIfXjmbg7h8xQQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@hyperjump/json-schema-core": "^0.28.0",
@@ -8760,9 +8760,9 @@
       }
     },
     "@hyperjump/json-schema": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.4.tgz",
-      "integrity": "sha512-4j3QDrLGTuaNYorXl2rXqdgQbjBbjDjlDHkQjONiZfMADkUU+Z2v8j5Mx1yIt/FZKL/8xnm/CG3D/Uz1L1+g8Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.2.tgz",
+      "integrity": "sha512-/m5emi8ruTGXxrsy6Pik4ipsjdUZVGePzqwm36oWtEB1DcExHnGheW/BDDBGrGZHdIqFV2PMTIfXjmbg7h8xQQ==",
       "requires": {
         "@hyperjump/json-schema-core": "^0.28.0",
         "fastest-stable-stringify": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "@hyperjump/json-schema": "^0.23.2",
+    "@hyperjump/json-schema": "0.23.2",
     "json-e": "^4.4.3",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0"


### PR DESCRIPTION
As of @hyperjump/json-schema-core@0.28.5 we are running into some issues where we cant install and use alterschema out of the box in a TS Jest environment.

This PR just freeze the dependency version until it can be updated to v1