### PR TITLE
Upgrade @hyperjump/json-schema to 0.23.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hyperjump/json-schema": "0.23.2",
+        "@hyperjump/json-schema": "^0.23.5",
         "json-e": "^4.4.3",
         "lodash": "^4.17.21",
         "object-hash": "^3.0.0"
@@ -582,13 +582,14 @@
       }
     },
     "node_modules/@hyperjump/json-schema": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.2.tgz",
-      "integrity": "sha512-/m5emi8ruTGXxrsy6Pik4ipsjdUZVGePzqwm36oWtEB1DcExHnGheW/BDDBGrGZHdIqFV2PMTIfXjmbg7h8xQQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.5.tgz",
+      "integrity": "sha512-gb1jOT6+BlZBR9Nc/tMGDt757YM7rjS71Dml3+TBYebdGOZlSrTzTfVAUfGzOlsceB3gP4K9b7HzAwEGMWmexQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@hyperjump/json-schema-core": "^0.28.0",
-        "fastest-stable-stringify": "^2.0.2"
+        "fastest-stable-stringify": "^2.0.2",
+        "just-curry-it": "^5.3.0"
       },
       "funding": {
         "type": "github",
@@ -612,6 +613,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/jdesrosiers"
       }
+    },
+    "node_modules/@hyperjump/json-schema/node_modules/just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="
     },
     "node_modules/@hyperjump/pact": {
       "version": "0.2.3",
@@ -8760,12 +8766,20 @@
       }
     },
     "@hyperjump/json-schema": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.2.tgz",
-      "integrity": "sha512-/m5emi8ruTGXxrsy6Pik4ipsjdUZVGePzqwm36oWtEB1DcExHnGheW/BDDBGrGZHdIqFV2PMTIfXjmbg7h8xQQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.5.tgz",
+      "integrity": "sha512-gb1jOT6+BlZBR9Nc/tMGDt757YM7rjS71Dml3+TBYebdGOZlSrTzTfVAUfGzOlsceB3gP4K9b7HzAwEGMWmexQ==",
       "requires": {
         "@hyperjump/json-schema-core": "^0.28.0",
-        "fastest-stable-stringify": "^2.0.2"
+        "fastest-stable-stringify": "^2.0.2",
+        "just-curry-it": "^5.3.0"
+      },
+      "dependencies": {
+        "just-curry-it": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+          "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="
+        }
       }
     },
     "@hyperjump/json-schema-core": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "@hyperjump/json-schema": "0.23.2",
+    "@hyperjump/json-schema": "^0.23.5",
     "json-e": "^4.4.3",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0"


### PR DESCRIPTION
This new version declares the missing `just-curry-it` dependency.

Fixes: https://github.com/sourcemeta/alterschema/issues/119
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
