### PR TITLE
fix(test): use 'equal' instead of 'is'

### DIFF
--- a/bindings/node/test.js
+++ b/bindings/node/test.js
@@ -217,7 +217,7 @@ tap.test('(CLI) draft4 => 2020-12', (test) => {
     }
   })
 
-  test.is(result.stderr.toString(), '')
-  test.is(result.status, 0)
+  test.equal(result.stderr.toString(), '')
+  test.equal(result.status, 0)
   test.end()
 })


### PR DESCRIPTION
It seems like the `test.is` in the test doesn't work. This substitutes it for `test.equal`.